### PR TITLE
fix: let the server be available on all network interfaces

### DIFF
--- a/src/vendure-config.ts
+++ b/src/vendure-config.ts
@@ -6,6 +6,7 @@ import path from 'path';
 
 export const config: VendureConfig = {
     apiOptions: {
+        hostname: '0.0.0.0',
         port: 3000,
         adminApiPath: 'admin-api',
         adminApiPlayground: {


### PR DESCRIPTION
Since I updated to v1-beta3, the server container couldn't be reached anymore by the docker host.
I modified the vendure config file to let the server being available on all network interfaces.

Tell me if you think there is a cleaner way, this is the quickest but maybe not the best one 😉 